### PR TITLE
Use go 1.16 to build darwin arm64 release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Import GPG key
         id: import_gpg
         uses: hashicorp/ghaction-import-gpg@v2.1.0


### PR DESCRIPTION
## Description

Bump Golang to 1.16  build Darwin ARM64 release to support M1 Macs. I see you already use go 1.16 in the "test" action. there is no reason not to use 1.16 to build releases.
