### PR TITLE
feat: Wait For DNS

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `timeout` - (Optional) Client timeout in seconds
 
+* `wait_for_dns` - (Optional) Whether to wait for the DNS record to be added for the host
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/terraform-providers/terraform-provider-http
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
+require (
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
+)
 
 go 1.13


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added the option to wait for DNS record to be added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This option makes waiting for AWS load balancer dns to be updated possible. Before there is the no such host error
```
dial tcp: lookup xxxxxxxx.elb.eu-west-2.amazonaws.com on 127.0.0.53:53: no such host
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
